### PR TITLE
Bugfix/optional chaining selected active color

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ export default class SwitchSelector extends Component {
     if (selected === -1) {
       return 'transparent';
     }
-    return options[selected].activeColor || buttonColor;
+    return options[selected]?.activeColor || buttonColor;
   }
 
   responderEnd = (evt, gestureState) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-switch-selector",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "description": "Switch Selector to React Native.",
     "main": "index.js",
     "types": "types/index.d.ts",


### PR DESCRIPTION
When I was updating my state I had the crashing saying that it failed to get an undefined value of options[selected].activeColor and I didn`t see any solution on the issues or at google.

But I realize that a simple optional chaining could fix this problem.

Link for issue: https://github.com/jkdrangel/react-native-switch-selector/issues/18

![image](https://user-images.githubusercontent.com/23662972/205300870-957565ee-ea33-4ac7-8a9e-a117458e81d4.png)
