### PR TITLE
Increased Button height to 100%

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const styles = {
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
+    height: '100%',
   },
   animated: {
     borderWidth: 0,


### PR DESCRIPTION
In our use case SwitchSelector has a height of 48 and sometimes when trying to press it doesn't register the touch since it's height is equal only to the size of the text.

If you have questions or feedback regarding this, I can try and make the changes accordingly.

Thanks!